### PR TITLE
Fix settings navigation and center startup window

### DIFF
--- a/lib/api/wsl.dart
+++ b/lib/api/wsl.dart
@@ -116,10 +116,32 @@ class WSLApi {
   }
 
   /// Stop a WSL distro by name
-  Future<String> stop(String distribution) async {
-    ProcessResult results =
-        await shell.run('wsl', ['--terminate', distribution]);
-    return results.stdout;
+  Future<String> stop(String distribution,
+      {Duration? timeout = const Duration(seconds: 30),
+      Duration pollInterval = const Duration(milliseconds: 500)}) async {
+    ProcessResult results = await shell.run(
+      'wsl.exe',
+      ['--terminate', distribution],
+      runInShell: true,
+    );
+    final terminateFailed = results.exitCode != 0;
+
+    final deadline = timeout == null ? null : DateTime.now().add(timeout);
+    while (deadline == null || DateTime.now().isBefore(deadline)) {
+      final running = await listRunning();
+      if (!running.any((name) => name.trim() == distribution.trim())) {
+        return results.stdout;
+      }
+      await Future.delayed(pollInterval);
+    }
+
+    if (terminateFailed) {
+      throw Exception(
+          "'$distribution' is still running. Close any open terminal sessions for this distro and try again. "
+          'WSL terminate failed with exit code ${results.exitCode}: ${results.stderr}');
+    }
+
+    throw Exception("Timed out waiting for '$distribution' to stop.");
   }
 
   /// Open bashrc with notepad from WSL

--- a/lib/components/list_item.dart
+++ b/lib/components/list_item.dart
@@ -27,6 +27,7 @@ class _ListItemState extends State<ListItem> {
   Map<String, bool> hover = {};
   bool isSyncing = false;
   bool isCleaning = false;
+  bool isStopping = false;
   bool showBar = false;
   bool hovered = false;
 
@@ -65,9 +66,7 @@ class _ListItemState extends State<ListItem> {
                       cursor: SystemMouseCursors.click,
                       child: IconButton(
                         icon: const Icon(FluentIcons.stop),
-                        onPressed: () {
-                          stopInstance();
-                        },
+                        onPressed: isStopping ? null : stopInstance,
                       ),
                     ),
                   )
@@ -98,11 +97,28 @@ class _ListItemState extends State<ListItem> {
     );
   }
 
-  void stopInstance() {
+  Future<void> stopInstance() async {
     plausible.event(name: "wsl_stopped");
-    WSLApi().stop(widget.item);
-    Notify.message('${widget.item} ${'stopped-text'.i18n()}.',
-        loading: false, duration: const Duration(seconds: 3));
+    if (mounted) {
+      setState(() {
+        isStopping = true;
+      });
+    }
+    Notify.message('Stopping ${distroLabel(widget.item)} ...', loading: true);
+    try {
+      await WSLApi().stop(widget.item);
+      Notify.message('${widget.item} ${'stopped-text'.i18n()}.',
+          loading: false, duration: const Duration(seconds: 3));
+    } catch (error) {
+      Notify.message('Failed to stop ${widget.item}: ${error.toString()}',
+          loading: false, duration: const Duration(seconds: 5));
+    } finally {
+      if (mounted) {
+        setState(() {
+          isStopping = false;
+        });
+      }
+    }
   }
 
   void startInstance() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,6 +48,7 @@ void main() async {
       );
       await windowManager.setMinimumSize(const Size(574, 450));
       await windowManager.setSize(const Size(800, 600));
+      await windowManager.center();
       await windowManager.show();
       await windowManager.setPreventClose(true);
       await windowManager.setSkipTaskbar(false);

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -143,7 +143,7 @@ class SettingsPageState extends State<SettingsPage> {
                           WSLApi().restart();
                           hasPushed = false;
 
-                          Navigator.popAndPushNamed(context, '/');
+                          router.pushNamed('home');
                         },
                         child: Text('stopwsl-text'.i18n())),
                   ),

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -53,6 +53,8 @@ class MockHttpClientAdapter implements HttpClientAdapter {
 
 class MockShell implements Shell {
   final List<String> distros = [];
+  final List<String> runningDistros = [];
+  int runningListCalls = 0;
   List<String> lastStartArguments = [];
   String lastStartExecutable = '';
   String? execCmdAsRootResponse;
@@ -63,6 +65,8 @@ class MockShell implements Shell {
   String importFailureStdout = '';
   bool simulateSmallExport = false;
   bool simulateRemoveFailure = false;
+  bool simulateTerminateFailure = false;
+  bool keepRunningAfterTerminate = false;
   bool simulateCodeMissing = false;
   bool simulateCodiumMissing = false;
 
@@ -92,7 +96,22 @@ class MockShell implements Shell {
     }
 
     if (arguments.contains('--list')) {
-      stdout = distros.join('\n');
+      if (arguments.contains('--running')) {
+        runningListCalls++;
+        stdout = runningDistros.join('\n');
+      } else {
+        stdout = distros.join('\n');
+      }
+    }
+
+    if (arguments.contains('--terminate')) {
+      if (!keepRunningAfterTerminate) {
+        runningDistros.remove(arguments[1]);
+      }
+      if (simulateTerminateFailure) {
+        stderr = 'Terminate failed';
+        exitCode = -1;
+      }
     }
 
     if (arguments.contains('--unregister')) {

--- a/test/wsl_test.dart
+++ b/test/wsl_test.dart
@@ -211,6 +211,56 @@ void main() {
     expect(await isInstance('testcopy2'), false);
   });
 
+  test('Stop waits until distro is no longer running', () async {
+    mockShell.distros.add('test');
+    mockShell.runningDistros.add('test');
+
+    await wslApi.stop(
+      'test',
+      timeout: const Duration(seconds: 1),
+      pollInterval: Duration.zero,
+    );
+
+    expect(mockShell.runningDistros, isNot(contains('test')));
+    expect(mockShell.runningListCalls, greaterThan(0));
+  });
+
+  test('Stop succeeds if terminate returns non-zero after distro stops',
+      () async {
+    mockShell.distros.add('test');
+    mockShell.runningDistros.add('test');
+    mockShell.simulateTerminateFailure = true;
+
+    await wslApi.stop(
+      'test',
+      timeout: const Duration(seconds: 1),
+      pollInterval: Duration.zero,
+    );
+
+    expect(mockShell.runningDistros, isNot(contains('test')));
+  });
+
+  test('Stop asks to close terminal sessions if distro keeps running',
+      () async {
+    mockShell.distros.add('test');
+    mockShell.runningDistros.add('test');
+    mockShell.simulateTerminateFailure = true;
+    mockShell.keepRunningAfterTerminate = true;
+
+    expect(
+      () => wslApi.stop(
+        'test',
+        timeout: const Duration(milliseconds: 1),
+        pollInterval: Duration.zero,
+      ),
+      throwsA(predicate(
+        (error) => error
+            .toString()
+            .contains('Close any open terminal sessions for this distro'),
+      )),
+    );
+  });
+
   test('Cleanup test', () async {
     // Create a new instance
     mockShell.distros.add('test');

--- a/windows/runner/win32_window.cpp
+++ b/windows/runner/win32_window.cpp
@@ -117,7 +117,7 @@ bool Win32Window::CreateAndShow(const std::wstring& title,
   double scale_factor = dpi / 96.0;
 
   HWND window = CreateWindow(
-      window_class, title.c_str(), WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+      window_class, title.c_str(), WS_OVERLAPPEDWINDOW,
       Scale(origin.x, scale_factor), Scale(origin.y, scale_factor),
       Scale(size.width, scale_factor), Scale(size.height, scale_factor),
       nullptr, nullptr, GetModuleHandle(nullptr), this);


### PR DESCRIPTION
## Summary
- use the app GoRouter when returning home from the Settings page Stop WSL button
- center the desktop window after setting its startup size and before showing it

## Verification
- git diff --check

Flutter/Dart SDK was not available in my local environment, so I could not run flutter analyze.